### PR TITLE
MotorolaQualcommRIL: override setDataAllowed

### DIFF
--- a/ril/MotorolaQualcommRIL.java
+++ b/ril/MotorolaQualcommRIL.java
@@ -131,4 +131,19 @@ public class MotorolaQualcommRIL extends RIL implements CommandsInterface {
             response.sendToTarget();
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDataAllowed(boolean allowed, Message result) {
+        riljLog("setDataAllowed: not supported");
+
+        if (result != null) {
+            CommandException e = new CommandException(
+                CommandException.Error.REQUEST_NOT_SUPPORTED);
+            AsyncResult.forMessage(result, null, e);
+            result.sendToTarget();
+        }
+    }
 }


### PR DESCRIPTION
Calls to setDataAllowed sometimes crashes rild due to unexpected
sim-io, so override the call as it isn't implemented in the ril
anyways.

Change-Id: I67c58fb7ef6c2d6a071bba2f985f159ba1beca10